### PR TITLE
Explicit classloader for ServiceLoader

### DIFF
--- a/ghostwriter-api-java/src/main/java/io/ghostwriter/GhostWriter.java
+++ b/ghostwriter-api-java/src/main/java/io/ghostwriter/GhostWriter.java
@@ -70,7 +70,7 @@ public enum GhostWriter {
     @SuppressWarnings({"rawtypes"})
     private static TracerProvider<?> initialize() {
         TracerProvider foundProv = null;
-        ServiceLoader<TracerProvider> serviceLoader = ServiceLoader.load(TracerProvider.class);
+        ServiceLoader<TracerProvider> serviceLoader = ServiceLoader.load(TracerProvider.class, GhostWriter.class.getClassLoader());
         for (TracerProvider tracerProvider : serviceLoader) {
             Tracer tracer = tracerProvider.getTracer();
             if (foundProv == null


### PR DESCRIPTION
By default when loading a service the current thread context class loader will be used. This can be null and in which case the system classloader will be the fallback.
This can be problematic if one uses a JEE container - like Wildfly - where the services will be loaded by the module class loader and tracing won't work.
By using the same classloader that loaded the GhostWriter class, services classes should be available (it fixes the Wildfly issue as well).